### PR TITLE
chore: add turborepo cache folder to default ignore

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,6 +92,8 @@ export const DEFAULT_IGNORES = [
   "tmp",
   // Our output file
   "codebase.md",
+  // Turborepo cache folder
+  ".turbo"
 ];
 
 export function removeWhitespace(val: string): string {


### PR DESCRIPTION
Add `.turbo` to the default ignores