### PR TITLE
feat: add option to set custom ignore file

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Run `npm run start` to run the CLI tool on the local project. (Very meta!)
 
 Run `npm test` to run the tests.
 
+To pass flags to the CLI, use the `--` flag, like this: `npm run start -- --whitespace-removal`.
+
 ## Deploy New Version
 
 ```

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ For best results, re-upload the Markdown file before starting a new chat session
 - `--no-default-ignores`: Disable default ignore patterns
 - `--whitespace-removal`: Enable whitespace removal
 - `--show-output-files`: Display a list of files included in the output
+- `--ignore-file <file>`: Specify a custom ignore file (default: .aidigestignore)
 - `--help`: Show help
 
 ## Examples

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import {
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB in bytes
 
-async function readIgnoreFile(inputDir: string, filename: string = '.aidigestignore'): Promise<string[]> {
+async function readIgnoreFile(inputDir: string, filename: string): Promise<string[]> {
   try {
     const filePath = path.join(inputDir, filename);
     const content = await fs.readFile(filePath, 'utf-8');
@@ -42,11 +42,11 @@ function displayIncludedFiles(includedFiles: string[]): void {
   });
 }
 
-async function aggregateFiles(inputDir: string, outputFile: string, useDefaultIgnores: boolean, removeWhitespaceFlag: boolean, showOutputFiles: boolean): Promise<void> {
+async function aggregateFiles(inputDir: string, outputFile: string, useDefaultIgnores: boolean, removeWhitespaceFlag: boolean, showOutputFiles: boolean, ignoreFile: string): Promise<void> {
   try {
-    const userIgnorePatterns = await readIgnoreFile(inputDir);
+    const userIgnorePatterns = await readIgnoreFile(inputDir, ignoreFile);
     const defaultIgnore = useDefaultIgnores ? ignore().add(DEFAULT_IGNORES) : ignore();
-    const customIgnore = createIgnoreFilter(userIgnorePatterns);
+    const customIgnore = createIgnoreFilter(userIgnorePatterns, ignoreFile);
 
     if (useDefaultIgnores) {
       console.log(formatLog('Using default ignore patterns.', '🚫'));
@@ -166,10 +166,11 @@ program
   .option('--no-default-ignores', 'Disable default ignore patterns')
   .option('--whitespace-removal', 'Enable whitespace removal')
   .option('--show-output-files', 'Display a list of files included in the output')
+  .option('--ignore-file <file>', 'Custom ignore file name', '.aidigestignore')
   .action(async (options) => {
     const inputDir = path.resolve(options.input);
     const outputFile = path.isAbsolute(options.output) ? options.output : path.join(process.cwd(), options.output);
-    await aggregateFiles(inputDir, outputFile, options.defaultIgnores, options.whitespaceRemoval, options.showOutputFiles);
+    await aggregateFiles(inputDir, outputFile, options.defaultIgnores, options.whitespaceRemoval, options.showOutputFiles, options.ignoreFile);
   });
 
 program.parse(process.argv);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,10 +102,10 @@ export function escapeTripleBackticks(content: string): string {
   return content.replace(/\`\`\`/g, "\\`\\`\\`");
 }
 
-export function createIgnoreFilter(ignorePatterns: string[]): Ignore {
+export function createIgnoreFilter(ignorePatterns: string[], ignoreFile: string): Ignore {
   const ig = require("ignore")().add(ignorePatterns);
   if (ignorePatterns.length > 0) {
-    console.log("Ignore patterns from .aidigestignore:");
+    console.log(`Ignore patterns from ${ignoreFile}:`);
     ignorePatterns.forEach((pattern) => {
       console.log(`  - ${pattern}`);
     });


### PR DESCRIPTION
As I want to use my `.gitignore` for ai-digest, I think this can be a good option to be able to set another file for setting ignore rules