### PR TITLE
FIX: godot *.tscn files should not be excluded from import

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,7 +48,6 @@ export const DEFAULT_IGNORES = [
   // Godot
   ".godot",
   "*.import",
-  "*.tscn",
   // Ruby
   "Gemfile.lock",
   ".bundle",


### PR DESCRIPTION
Just a quick fix in `utils.ts`, since the Godot Scene files `*.tscn` should not be excluded from the import (sorry for my previous PR...)