### PR TITLE
add new bun lockfile format to default ignores

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,6 +29,7 @@ export const DEFAULT_IGNORES = [
   "pnpm-lock.yaml",
   // Bun
   "bun.lockb",
+  "bun.lock",
   // Deno
   "deno.lock",
   // PHP (Composer)


### PR DESCRIPTION
since bun 1.2, it uses `bun.lock` by default instead of `bun.lockb`