### PR TITLE
Add .npmignore to exclude unnecessary files from package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,15 @@
+# Exclude Claude Code instructions
+CLAUDE.md
+
+# Exclude test files and directories
+test/
+test-library-mode/
+*.test.ts
+
+# Exclude configuration files
+jest.config.js
+tsconfig.json
+.claude
+.aidigestignore
+.github
+.nvmrc


### PR DESCRIPTION
Introduces a .npmignore file to prevent test files, configuration files, and documentation from being published to npm, reducing package size and exposure of internal resources.