### PR TITLE
Add getFileStats function to retrieve file statistics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ This is a CLI tool called "ai-digest" that aggregates files into a single Markdo
 - `generateDigestContent()` - Core function that processes files and returns content + stats
 - `writeDigestToFile()` - Writes digest content to file with stats display
 - `watchFiles()` - Implements file watching for auto-rebuild functionality
-- `getFileStats()` - Returns file statistics (path, size, token counts) sorted by size without content (added in v1.3.0)
+- `getFileStats()` - Returns file statistics (path, size) sorted by size with total token counts, without content (added in v1.3.0)
 
 ### File Processing Flow
 1. Read ignore patterns from `.aidigestignore` and apply default ignores
@@ -49,7 +49,7 @@ The tool exports functions for programmatic use:
 - `generateDigestContent(options)` - Lower-level function returning content and stats
 - `writeDigestToFile(content, outputFile, stats)` - File writing utility
 - `generateDigestFiles(options)` - Returns array of processed file objects with content
-- `getFileStats(options)` - Returns file statistics sorted by size (largest first) with token counts but no content
+- `getFileStats(options)` - Returns file statistics sorted by size (largest first) with total token counts but no content
 
 ## Code Style
 - Use 2 spaces for indentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,10 +52,7 @@ The architecture supports two usage patterns:
 - `watchFiles()` - Implements file watching with debouncing for auto-rebuild
 
 ### File Size Calculation Strategy
-The tool calculates two different file sizes depending on context:
-- **For CLI display (`--show-output-files`)**: Uses processed content size (markdown wrapper + content)
-- **For `getFileStats()` function**: Uses processed content size for consistency
-- **Original file sizes**: Only tracked internally during processing but not exposed in final APIs
+The tool consistently uses processed content size (markdown wrapper + content) for all file size calculations and displays. This ensures consistency between CLI output and library functions.
 
 ### Testing Architecture
 - **CLI Tests**: Use `execAsync` with `ts-node` to test actual CLI behavior
@@ -77,7 +74,6 @@ The tool exports functions for programmatic use:
 - `generateDigestFiles(options)` - Returns `{ files }` array for custom filtering/processing
 - `getFileStats(options)` - Returns file statistics sorted by size with total token counts, no content
 - `writeDigestToFile(content, outputFile, stats, showOutputFiles, fileSizes)` - File writing utility
-- `processFiles(options)` - Low-level processing function returning files and stats
 
 ## Code Style & Patterns
 - Use 2 spaces for indentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Single test: `npx jest src/index.test.ts -t "should respect custom output file"` - Run specific test
 - Format: `npm run prettier` - Format code with Prettier
 
+## Version Management
+When adding a new feature or making significant changes:
+1. Bump the version in package.json following semantic versioning:
+   - MAJOR version for incompatible API changes
+   - MINOR version for new functionality in a backward compatible manner (e.g., 1.2.4 → 1.3.0)
+   - PATCH version for backward compatible bug fixes
+2. Run `npm install` to update package-lock.json
+3. Document the new feature/change in CLAUDE.md with version number
+4. Claude should automatically suggest version bumping when a new feature is added (only once per conversation)
+
 ## Project Architecture
 
 This is a CLI tool called "ai-digest" that aggregates files into a single Markdown file for use with AI models. It can be used both as a CLI tool and as a Node.js library.
@@ -23,6 +33,7 @@ This is a CLI tool called "ai-digest" that aggregates files into a single Markdo
 - `generateDigestContent()` - Core function that processes files and returns content + stats
 - `writeDigestToFile()` - Writes digest content to file with stats display
 - `watchFiles()` - Implements file watching for auto-rebuild functionality
+- `getFileStats()` - Returns file statistics (path, size, token counts) sorted by size without content (added in v1.3.0)
 
 ### File Processing Flow
 1. Read ignore patterns from `.aidigestignore` and apply default ignores
@@ -37,6 +48,8 @@ The tool exports functions for programmatic use:
 - `generateDigest(options)` - Returns content string when `outputFile: null`
 - `generateDigestContent(options)` - Lower-level function returning content and stats
 - `writeDigestToFile(content, outputFile, stats)` - File writing utility
+- `generateDigestFiles(options)` - Returns array of processed file objects with content
+- `getFileStats(options)` - Returns file statistics sorted by size (largest first) with token counts but no content
 
 ## Code Style
 - Use 2 spaces for indentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,11 +3,13 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Commands
-- Build: `npm run build` - Compiles TypeScript code
-- Start: `npm run start` - Run the application with ts-node
+- Build: `npm run build` - Compiles TypeScript code to dist/
+- Start: `npm run start` - Run the application with ts-node for development
 - Test: `npm run test` - Run all Jest tests
-- Single test: `npx jest src/index.test.ts -t "should respect custom output file"` - Run specific test
-- Format: `npm run prettier` - Format code with Prettier
+- Single test: `npx jest src/index.test.ts -t "test name"` - Run specific test by name
+- Update snapshots: `npm run test -- -u` - Update Jest snapshots after changes
+- Format: `npm run prettier` - Format code with Prettier (excludes .snap files)
+- Publish: `npm run prepublishOnly` - Automatically runs build before publishing
 
 ## Version Management
 When adding a new feature or making significant changes:
@@ -21,45 +23,71 @@ When adding a new feature or making significant changes:
 
 ## Project Architecture
 
-This is a CLI tool called "ai-digest" that aggregates files into a single Markdown file for use with AI models. It can be used both as a CLI tool and as a Node.js library.
+This is a CLI tool called "ai-digest" that aggregates files into a single Markdown file for use with AI models. It operates both as a CLI tool (via Commander.js) and as a Node.js library with multiple export patterns.
 
-### Core Components
-- `src/index.ts` - Main entry point containing CLI logic and library exports
-- `src/utils.ts` - Utility functions for file processing, token counting, and ignore patterns
-- `src/index.test.ts` - Jest tests for both CLI and library functionality
+### Dual CLI/Library Design
+The architecture supports two usage patterns:
+- **CLI Mode**: Command-line interface with file watching, progress display, and console output
+- **Library Mode**: Programmatic API returning data structures for integration with other tools
 
-### Key Functions
-- `generateDigest()` - Main library function for external usage
-- `generateDigestContent()` - Core function that processes files and returns content + stats
-- `writeDigestToFile()` - Writes digest content to file with stats display
-- `watchFiles()` - Implements file watching for auto-rebuild functionality
-- `getFileStats()` - Returns file statistics (path, size) sorted by size with total token counts, without content (added in v1.3.0)
+### Core Processing Pipeline
+1. **File Discovery**: Uses glob patterns to scan directories, respecting ignore patterns
+2. **Binary Detection**: Separates text files from binary files using `isbinaryfile` and file extensions
+3. **Content Processing**: Text files are wrapped in markdown code blocks; binary files get descriptive text
+4. **Token Estimation**: Calculates token counts using both GPT-4 and Claude tokenizers
+5. **Output Generation**: Combines processed files into a single markdown document
 
-### File Processing Flow
-1. Read ignore patterns from `.aidigestignore` and apply default ignores
-2. Scan directories using glob patterns
-3. Filter files based on ignore patterns and binary detection
-4. Process text files with optional whitespace removal
-5. Generate Markdown output with syntax highlighting
-6. Calculate token counts for both GPT and Claude models
+### Key Components
+- `src/index.ts` - Main entry point containing CLI logic, library exports, and core processing functions
+- `src/utils.ts` - Utility functions for file processing, token counting, ignore patterns, and file type detection
+- `src/index.test.ts` - Comprehensive test suite covering both CLI and library functionality
+
+### Critical Functions
+- `processFiles()` - Core processing pipeline that handles file discovery, content processing, and statistics
+- `generateDigestContent()` - Main library function that returns content + files + stats
+- `generateDigest()` - Higher-level function for simple string output or file writing
+- `generateDigestFiles()` - Returns array of processed file objects for custom processing
+- `getFileStats()` - Returns file statistics sorted by processed content size with total token counts (added in v1.3.0)
+- `writeDigestToFile()` - Handles file writing with progress display and statistics
+- `watchFiles()` - Implements file watching with debouncing for auto-rebuild
+
+### File Size Calculation Strategy
+The tool calculates two different file sizes depending on context:
+- **For CLI display (`--show-output-files`)**: Uses processed content size (markdown wrapper + content)
+- **For `getFileStats()` function**: Uses processed content size for consistency
+- **Original file sizes**: Only tracked internally during processing but not exposed in final APIs
+
+### Testing Architecture
+- **CLI Tests**: Use `execAsync` with `ts-node` to test actual CLI behavior
+- **Library Tests**: Direct function imports for unit testing
+- **Temporary Directories**: Each test creates isolated temp directories for file operations
+- **Snapshot Testing**: Used for complex output structures (file stats, processed content)
+- **Binary File Testing**: Includes tests for actual binary files (mascot.jpg, smiley.svg)
+
+### Token Counting
+Dual tokenization using:
+- `js-tiktoken` for GPT-4 compatibility
+- `@anthropic-ai/tokenizer` for Claude models
+- Graceful fallback to approximations if tokenization fails
 
 ## Library Usage
 The tool exports functions for programmatic use:
-- `generateDigest(options)` - Returns content string when `outputFile: null`
-- `generateDigestContent(options)` - Lower-level function returning content and stats
-- `writeDigestToFile(content, outputFile, stats)` - File writing utility
-- `generateDigestFiles(options)` - Returns array of processed file objects with content
-- `getFileStats(options)` - Returns file statistics sorted by size (largest first) with total token counts but no content
+- `generateDigest(options)` - Returns content string when `outputFile: null`, writes file otherwise
+- `generateDigestContent(options)` - Returns `{ content, files, stats }` for full control
+- `generateDigestFiles(options)` - Returns `{ files }` array for custom filtering/processing
+- `getFileStats(options)` - Returns file statistics sorted by size with total token counts, no content
+- `writeDigestToFile(content, outputFile, stats, showOutputFiles, fileSizes)` - File writing utility
+- `processFiles(options)` - Low-level processing function returning files and stats
 
-## Code Style
+## Code Style & Patterns
 - Use 2 spaces for indentation
 - Prefer double quotes for strings
 - Explicit typing for function parameters and returns
 - Use async/await for asynchronous operations
-- Use camelCase for variable and function names
-- Handle errors with try/catch blocks (see formatLog for error logging)
-- Group related constants at the top of the file
-- Use descriptive variable names
-- Wrap CLI calls in utility functions when testing
+- Handle errors with try/catch blocks using `formatLog` for consistent error formatting
+- Group related constants at the top of files
+- Use descriptive variable names and avoid abbreviations
+- Wrap CLI execution in utility functions when testing (`runCLI`, `runCLIWithEnv`)
 - Add timeout values to Jest tests for file operations (10000-15000ms)
-- Document CLI options in program declarations
+- Use snapshot testing for complex data structures that should remain stable
+- Binary files should be tested with actual binary data, not mocked content

--- a/README.md
+++ b/README.md
@@ -132,6 +132,21 @@ console.log(files[0].content);   // "# index.ts\n\n```ts\n// file content...\n``
 // Apply custom filtering after processing
 const jsFiles = files.filter(file => file.fileName.endsWith('.js'));
 const customDigest = jsFiles.map(file => file.content).join('');
+
+// Get file statistics without content (useful for analysis)
+const stats = await aiDigest.getFileStats({
+  inputDir: './src',
+  silent: true
+});
+
+// Returns files sorted by size (largest first) with token counts
+console.log(stats.files[0]);
+// {
+//   path: 'large-file.js',
+//   sizeInBytes: 15420,
+//   gptTokens: 3821,
+//   claudeTokens: 4102
+// }
 ```
 
 **Available functions:**
@@ -139,6 +154,7 @@ const customDigest = jsFiles.map(file => file.content).join('');
 - `generateDigestFiles(options)` - Generate digest and return array of individual file objects
 - `generateDigestContent(options)` - Lower-level function that returns content and stats
 - `writeDigestToFile(content, outputFile, stats)` - Write digest content to a file
+- `getFileStats(options)` - Get file statistics (path, size, token counts) sorted by size without content
 
 ## Custom Ignore Patterns
 

--- a/README.md
+++ b/README.md
@@ -139,13 +139,16 @@ const stats = await aiDigest.getFileStats({
   silent: true
 });
 
-// Returns files sorted by size (largest first) with token counts
-console.log(stats.files[0]);
+// Returns files sorted by size (largest first) with total token counts
+console.log(stats);
 // {
-//   path: 'large-file.js',
-//   sizeInBytes: 15420,
-//   gptTokens: 3821,
-//   claudeTokens: 4102
+//   files: [
+//     { path: 'large-file.js', sizeInBytes: 15420 },
+//     { path: 'medium-file.ts', sizeInBytes: 8200 },
+//     { path: 'small-file.txt', sizeInBytes: 1024 }
+//   ],
+//   totalGptTokens: 5850,
+//   totalClaudeTokens: 6284
 // }
 ```
 
@@ -154,7 +157,7 @@ console.log(stats.files[0]);
 - `generateDigestFiles(options)` - Generate digest and return array of individual file objects
 - `generateDigestContent(options)` - Lower-level function that returns content and stats
 - `writeDigestToFile(content, outputFile, stats)` - Write digest content to a file
-- `getFileStats(options)` - Get file statistics (path, size, token counts) sorted by size without content
+- `getFileStats(options)` - Get file statistics (path, size) sorted by size with total token counts, without content
 
 ## Custom Ignore Patterns
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-digest",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-digest",
-      "version": "1.2.4",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "start": "ts-node src/index.ts",
     "prepublishOnly": "npm run build",
     "test": "jest --config jest.config.js",
-    "prettier": "prettier --write \"src/**/*\""
+    "prettier": "prettier --write \"src/**/*.{js,ts,json}\" \"!src/**/*.snap\""
   },
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-digest",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "CLI tool to aggregate files into a single Markdown file",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AI Digest Library API should return file statistics sorted by size with getFileStats 1`] = `
+{
+  "files": [
+    {
+      "claudeTokens": 212,
+      "gptTokens": 189,
+      "path": "large.md",
+      "sizeInBytes": 884,
+    },
+    {
+      "claudeTokens": 20,
+      "gptTokens": 16,
+      "path": "medium.js",
+      "sizeInBytes": 58,
+    },
+    {
+      "claudeTokens": 21,
+      "gptTokens": 18,
+      "path": "file2.js",
+      "sizeInBytes": 54,
+    },
+    {
+      "claudeTokens": 21,
+      "gptTokens": 19,
+      "path": "subdir/file3.py",
+      "sizeInBytes": 54,
+    },
+    {
+      "claudeTokens": 16,
+      "gptTokens": 15,
+      "path": "file1.txt",
+      "sizeInBytes": 40,
+    },
+    {
+      "claudeTokens": 13,
+      "gptTokens": 11,
+      "path": "small.txt",
+      "sizeInBytes": 30,
+    },
+  ],
+}
+`;

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -4,41 +4,31 @@ exports[`AI Digest Library API should return file statistics sorted by size with
 {
   "files": [
     {
-      "claudeTokens": 212,
-      "gptTokens": 189,
       "path": "large.md",
       "sizeInBytes": 884,
     },
     {
-      "claudeTokens": 20,
-      "gptTokens": 16,
       "path": "medium.js",
       "sizeInBytes": 58,
     },
     {
-      "claudeTokens": 21,
-      "gptTokens": 18,
       "path": "file2.js",
       "sizeInBytes": 54,
     },
     {
-      "claudeTokens": 21,
-      "gptTokens": 19,
       "path": "subdir/file3.py",
       "sizeInBytes": 54,
     },
     {
-      "claudeTokens": 16,
-      "gptTokens": 15,
       "path": "file1.txt",
       "sizeInBytes": 40,
     },
     {
-      "claudeTokens": 13,
-      "gptTokens": 11,
       "path": "small.txt",
       "sizeInBytes": 30,
     },
   ],
+  "totalClaudeTokens": 303,
+  "totalGptTokens": 268,
 }
 `;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -789,8 +789,8 @@ describe("AI Digest Library API", () => {
     expect(mascotFile).toBeDefined();
     expect(mascotFile!.path).toBe("mascot.jpg");
 
-    // Verify the file size matches actual binary file size (10732 bytes)
-    expect(mascotFile!.sizeInBytes).toBe(10732);
+    // Verify the file size matches processed text content size (56 bytes for "# mascot.jpg\n\nThis is a binary file of the type: Image\n\n")
+    expect(mascotFile!.sizeInBytes).toBe(56);
 
     // Verify that only path and sizeInBytes are present (no token counts per file)
     expect(mascotFile!).toHaveProperty("path");

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,6 +10,7 @@ import aiDigest, {
   generateDigestFiles,
   generateDigestContent,
   writeDigestToFile,
+  getFileStats,
 } from "./index";
 
 const execAsync = promisify(exec);
@@ -692,7 +693,7 @@ describe("AI Digest Library API", () => {
       // With multiple directories, all files should be prefixed with directory name
       const tempDir1Name = path.basename(tempDir);
       const tempDir2Name = path.basename(tempDir2);
-      
+
       expect(fileNames).toContain(`${tempDir1Name}/file1.txt`);
       expect(fileNames).toContain(`${tempDir1Name}/file2.js`);
       expect(fileNames).toContain(`${tempDir2Name}/file4.md`);
@@ -726,5 +727,49 @@ describe("AI Digest Library API", () => {
     expect(binaryFile).toBeDefined();
     expect(binaryFile!.content).toContain("# image.png");
     expect(binaryFile!.content).toContain("This is a binary file of the type:");
+  });
+
+  it("should return file statistics sorted by size with getFileStats", async () => {
+    // Create files with different sizes
+    await fs.writeFile(path.join(tempDir, "small.txt"), "tiny");
+    await fs.writeFile(
+      path.join(tempDir, "medium.js"),
+      "console.log('medium sized file');",
+    );
+    await fs.writeFile(
+      path.join(tempDir, "large.md"),
+      "# Large file\n\nThis is a much larger file with more content to ensure different sizes.\n".repeat(
+        10,
+      ),
+    );
+
+    const result = await getFileStats({
+      inputDir: tempDir,
+      silent: true,
+    });
+
+    expect(result).toHaveProperty("files");
+    expect(Array.isArray(result.files)).toBe(true);
+    expect(result.files.length).toBeGreaterThanOrEqual(3);
+
+    // Check that files are sorted by size (largest first)
+    for (let i = 1; i < result.files.length; i++) {
+      expect(result.files[i - 1].sizeInBytes).toBeGreaterThanOrEqual(
+        result.files[i].sizeInBytes,
+      );
+    }
+
+    // Check file properties
+    const firstFile = result.files[0];
+    expect(firstFile).toHaveProperty("path");
+    expect(firstFile).toHaveProperty("sizeInBytes");
+    expect(firstFile).toHaveProperty("gptTokens");
+    expect(firstFile).toHaveProperty("claudeTokens");
+
+    // Check that token counts are numbers
+    expect(typeof firstFile.gptTokens).toBe("number");
+    expect(typeof firstFile.claudeTokens).toBe("number");
+    expect(firstFile.gptTokens).toBeGreaterThanOrEqual(0);
+    expect(firstFile.claudeTokens).toBeGreaterThanOrEqual(0);
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -771,5 +771,8 @@ describe("AI Digest Library API", () => {
     expect(typeof firstFile.claudeTokens).toBe("number");
     expect(firstFile.gptTokens).toBeGreaterThanOrEqual(0);
     expect(firstFile.claudeTokens).toBeGreaterThanOrEqual(0);
+
+    // Snapshot test the actual output
+    expect(result).toMatchSnapshot();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,7 +154,6 @@ export async function processFiles(options: {
     binaryAndSvgFileCount: number;
     includedFiles: string[];
     fileSizeInBytes: number;
-    originalFileSizes: Record<string, number>;
   };
 }> {
   const {
@@ -354,7 +353,6 @@ export async function processFiles(options: {
         binaryAndSvgFileCount,
         includedFiles,
         fileSizeInBytes: totalContentSize,
-        originalFileSizes: fileSizes,
       },
     };
   } catch (error) {
@@ -1048,7 +1046,7 @@ export async function getFileStats(
         : path.join(getActualWorkingDirectory(), outputFile);
 
   // Process files to get the content
-  const { files, stats } = await processFiles({
+  const { files } = await processFiles({
     inputDirs: directories,
     outputFilePath: resolvedOutputFile,
     useDefaultIgnores,
@@ -1080,7 +1078,7 @@ export async function getFileStats(
 
     return {
       path: file.fileName,
-      sizeInBytes: stats.originalFileSizes[file.fileName] || Buffer.byteLength(file.content),
+      sizeInBytes: Buffer.byteLength(file.content),
     };
   });
 


### PR DESCRIPTION
Introduces a new getFileStats API that returns file statistics (path, size, GPT and Claude token counts) sorted by size, without file content. Updates README with usage instructions and adds comprehensive tests for the new function.